### PR TITLE
Parameterize adjudication SQL in Shiny reviewer app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Depends:
 	R (>= 4.1.0)
 Imports:
   checkmate,
+  DBI,
   dplyr,
   SqlRender,
   english,

--- a/R/ShinyDbHelpers.R
+++ b/R/ShinyDbHelpers.R
@@ -1,0 +1,93 @@
+# Copyright 2026 Observational Health Data Sciences and Informatics
+#
+# This file is part of Keeper
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Internal helpers used by the reviewer Shiny app (inst/shiny/server.R)
+# to persist adjudication decisions to a database. These replace
+# SqlRender @-token templates, whose textual substitution is unsafe for
+# values that are user-supplied (`decision`, `certainty`, `index_day`)
+# or that may legitimately contain apostrophes (phenotype names such as
+# "Crohn's disease", database identifiers, etc.). Only the schema and
+# column name are interpolated into the SQL — both after strict allowlist
+# validation. Every other value is bound as a DBI parameter.
+
+validateAdjudicationColumn <- function(column) {
+  allowedColumns <- c("decision", "certainty", "index_day")
+  if (!is.character(column) || length(column) != 1L ||
+      is.na(column) || !column %in% allowedColumns) {
+    stop(sprintf(
+      "Invalid column '%s'; must be one of: %s",
+      paste(column, collapse = ", "),
+      paste(allowedColumns, collapse = ", ")
+    ), call. = FALSE)
+  }
+  invisible(column)
+}
+
+validateDatabaseSchema <- function(databaseSchema) {
+  pattern <- "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?$"
+  if (!is.character(databaseSchema) || length(databaseSchema) != 1L ||
+      is.na(databaseSchema) || !grepl(pattern, databaseSchema)) {
+    stop(sprintf(
+      "Invalid databaseSchema: '%s'",
+      paste(databaseSchema, collapse = ", ")
+    ), call. = FALSE)
+  }
+  invisible(databaseSchema)
+}
+
+buildUpdateAdjudicationSql <- function(databaseSchema, column) {
+  validateDatabaseSchema(databaseSchema)
+  validateAdjudicationColumn(column)
+  sprintf(
+    paste(
+      "UPDATE %s.adjudications",
+      "SET %s = ?",
+      "WHERE database_id = ?",
+      "AND phenotype = ?",
+      "AND generated_id = ?",
+      "AND adjudicator = ?"
+    ),
+    databaseSchema, column
+  )
+}
+
+# Thin wrapper over DBI::dbExecute so tests can stub out execution.
+executeAdjudicationSql <- function(connection, sql, params) {
+  DBI::dbExecute(connection, sql, params = params)
+}
+
+updateAdjudication <- function(connection,
+                                databaseSchema,
+                                column,
+                                value,
+                                databaseId,
+                                phenotype,
+                                generatedId,
+                                adjudicator) {
+  sql <- buildUpdateAdjudicationSql(databaseSchema, column)
+  executeAdjudicationSql(
+    connection = connection,
+    sql = sql,
+    params = list(
+      value,
+      databaseId,
+      phenotype,
+      as.integer(generatedId),
+      adjudicator
+    )
+  )
+  invisible(NULL)
+}

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -248,26 +248,18 @@ shinyServer(function(input, output, session) {
       write_csv(decisions$decisionsDataFrame, dataList$decisions$fileName)
     } else if (dataList$decisions$type == "database") {
       writeLines(sprintf("Updating database, setting decision to %s", input$decision))
-      key <- keeperSubset() |> 
+      key <- keeperSubset() |>
         head(1) |>
         select(databaseId, phenotype, generatedId)
-      sql <- "UPDATE @database_schema.adjudications
-        SET decision = '@decision'
-        WHERE database_id = '@database_id'
-          AND phenotype = '@phenotype'
-          AND generated_id = @generated_id
-          AND adjudicator = '@adjudicator';"
-      DatabaseConnector::renderTranslateExecuteSql(
-        connection = connectionPool,
-        sql = sql,
-        database_schema = databaseSchema,
-        database_id = key$databaseId,
-        phenotype = key$phenotype,
-        generated_id = key$generatedId,
-        adjudicator = dataList$adjudicator,
-        decision = input$decision,
-        progressBar = FALSE,
-        reportOverallTime = FALSE
+      Keeper:::updateAdjudication(
+        connection     = connectionPool,
+        databaseSchema = databaseSchema,
+        column         = "decision",
+        value          = input$decision,
+        databaseId     = key$databaseId,
+        phenotype      = key$phenotype,
+        generatedId    = key$generatedId,
+        adjudicator    = dataList$adjudicator
       )
     }
   }, ignoreInit = TRUE)
@@ -278,26 +270,18 @@ shinyServer(function(input, output, session) {
       write_csv(decisions$decisionsDataFrame, dataList$decisions$fileName)
     } else if (dataList$decisions$type == "database") {
       writeLines(sprintf("Updating database, setting certainty to %s", input$certainty))
-      key <- keeperSubset() |> 
+      key <- keeperSubset() |>
         head(1) |>
         select(databaseId, phenotype, generatedId)
-      sql <- "UPDATE @database_schema.adjudications
-        SET certainty = '@certainty'
-        WHERE database_id = '@database_id'
-          AND phenotype = '@phenotype'
-          AND generated_id = @generated_id
-          AND adjudicator = '@adjudicator';"
-      DatabaseConnector::renderTranslateExecuteSql(
-        connection = connectionPool,
-        sql = sql,
-        database_schema = databaseSchema,
-        database_id = key$databaseId,
-        phenotype = key$phenotype,
-        generated_id = key$generatedId,
-        adjudicator = dataList$adjudicator,
-        certainty = input$certainty,
-        progressBar = FALSE,
-        reportOverallTime = FALSE
+      Keeper:::updateAdjudication(
+        connection     = connectionPool,
+        databaseSchema = databaseSchema,
+        column         = "certainty",
+        value          = input$certainty,
+        databaseId     = key$databaseId,
+        phenotype      = key$phenotype,
+        generatedId    = key$generatedId,
+        adjudicator    = dataList$adjudicator
       )
     }
   }, ignoreInit = TRUE)
@@ -312,26 +296,18 @@ shinyServer(function(input, output, session) {
       write_csv(decisions$decisionsDataFrame, dataList$decisions$fileName)
     } else if (dataList$decisions$type == "database") {
       writeLines(sprintf("Updating database, setting index_day to %s", delayedIndexDay()))
-      key <- keeperSubset() |> 
+      key <- keeperSubset() |>
         head(1) |>
         select(databaseId, phenotype, generatedId)
-      sql <- "UPDATE @database_schema.adjudications
-        SET index_day = @index_day
-        WHERE database_id = '@database_id'
-          AND phenotype = '@phenotype'
-          AND generated_id = @generated_id
-          AND adjudicator = '@adjudicator';"
-      DatabaseConnector::renderTranslateExecuteSql(
-        connection = connectionPool,
-        sql = sql,
-        database_schema = databaseSchema,
-        database_id = key$databaseId,
-        phenotype = key$phenotype,
-        generated_id = key$generatedId,
-        adjudicator = dataList$adjudicator,
-        index_day = delayedIndexDay(),
-        progressBar = FALSE,
-        reportOverallTime = FALSE
+      Keeper:::updateAdjudication(
+        connection     = connectionPool,
+        databaseSchema = databaseSchema,
+        column         = "index_day",
+        value          = delayedIndexDay(),
+        databaseId     = key$databaseId,
+        phenotype      = key$phenotype,
+        generatedId    = key$generatedId,
+        adjudicator    = dataList$adjudicator
       )
     }
   }, ignoreInit = TRUE)

--- a/tests/testthat/test-shiny-db-helpers.R
+++ b/tests/testthat/test-shiny-db-helpers.R
@@ -1,0 +1,164 @@
+library(Keeper)
+library(testthat)
+
+# These tests guard against a SQL-injection regression in the reviewer
+# Shiny app. The original `inst/shiny/server.R` built UPDATE statements by
+# textual substitution (SqlRender `@parameter` tokens wrapped in single
+# quotes), which both (a) broke on legitimate phenotype names containing an
+# apostrophe (e.g. "Crohn's disease") and (b) allowed an attacker who could
+# influence any interpolated value to inject arbitrary SQL. The new helpers
+# allowlist the only two identifiers that MUST be interpolated (schema and
+# column), and pass every user-supplied value to DBI as a bound parameter.
+
+test_that("buildUpdateAdjudicationSql emits bind placeholders, not inline values", {
+  for (column in c("decision", "certainty", "index_day")) {
+    sql <- Keeper:::buildUpdateAdjudicationSql("public", column)
+    expect_match(sql, sprintf("SET %s = \\?", column))
+    expect_match(sql, "WHERE database_id = \\?")
+    expect_match(sql, "AND phenotype = \\?")
+    expect_match(sql, "AND generated_id = \\?")
+    expect_match(sql, "AND adjudicator = \\?")
+    expect_false(
+      grepl("'", sql, fixed = TRUE),
+      info = "SQL must not contain inline string literals"
+    )
+  }
+})
+
+test_that("buildUpdateAdjudicationSql rejects non-allowlisted columns", {
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql("public", "arbitrary"),
+    "Invalid column"
+  )
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql(
+      "public", "decision = 'Case'; DROP TABLE users; --"),
+    "Invalid column"
+  )
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql("public", c("decision", "certainty")),
+    "Invalid column"
+  )
+})
+
+test_that("buildUpdateAdjudicationSql rejects unsafe schema names", {
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql(
+      "public'; DROP TABLE users; --", "decision"),
+    "Invalid databaseSchema"
+  )
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql("", "decision"),
+    "Invalid databaseSchema"
+  )
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql("1public", "decision"),
+    "Invalid databaseSchema"
+  )
+  expect_error(
+    Keeper:::buildUpdateAdjudicationSql("public schema", "decision"),
+    "Invalid databaseSchema"
+  )
+})
+
+test_that("buildUpdateAdjudicationSql accepts database.schema form", {
+  sql <- Keeper:::buildUpdateAdjudicationSql("my_db.my_schema", "decision")
+  expect_match(sql, "UPDATE my_db\\.my_schema\\.adjudications")
+})
+
+test_that("updateAdjudication binds user-supplied values as parameters", {
+  captured <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    executeAdjudicationSql = function(connection, sql, params) {
+      captured$sql <- sql
+      captured$params <- params
+      1L
+    },
+    .package = "Keeper"
+  )
+
+  Keeper:::updateAdjudication(
+    connection     = "fake_conn",
+    databaseSchema = "public",
+    column         = "decision",
+    value          = "Case",
+    databaseId     = "DB_1",
+    phenotype      = "Crohn's disease",
+    generatedId    = 42,
+    adjudicator    = "ALICE"
+  )
+
+  # A phenotype legitimately containing an apostrophe must never appear
+  # in the SQL text; it travels as a bound parameter instead.
+  expect_false(grepl("Crohn", captured$sql, fixed = TRUE))
+  expect_false(grepl("'", captured$sql, fixed = TRUE))
+  expect_equal(
+    captured$params,
+    list("Case", "DB_1", "Crohn's disease", 42L, "ALICE")
+  )
+})
+
+test_that("updateAdjudication neutralizes injection payloads in value", {
+  captured <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    executeAdjudicationSql = function(connection, sql, params) {
+      captured$sql <- sql
+      captured$params <- params
+      1L
+    },
+    .package = "Keeper"
+  )
+
+  injectionPayload <- "Case', adjudicator='attacker'; --"
+  Keeper:::updateAdjudication(
+    connection     = "fake_conn",
+    databaseSchema = "public",
+    column         = "decision",
+    value          = injectionPayload,
+    databaseId     = "DB_1",
+    phenotype      = "AFib",
+    generatedId    = 1,
+    adjudicator    = "ALICE"
+  )
+
+  # The payload must not appear in the SQL; it rides in params.
+  expect_false(grepl("attacker", captured$sql, fixed = TRUE))
+  expect_false(grepl("DROP",     captured$sql, fixed = TRUE))
+  expect_equal(captured$params[[1]], injectionPayload)
+})
+
+test_that("updateAdjudication coerces generatedId to integer", {
+  captured <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    executeAdjudicationSql = function(connection, sql, params) {
+      captured$params <- params
+      1L
+    },
+    .package = "Keeper"
+  )
+
+  Keeper:::updateAdjudication(
+    connection     = "fake_conn",
+    databaseSchema = "public",
+    column         = "index_day",
+    value          = 5L,
+    databaseId     = "DB_1",
+    phenotype      = "AFib",
+    generatedId    = "42",
+    adjudicator    = "ALICE"
+  )
+
+  expect_identical(captured$params[[4]], 42L)
+})
+
+test_that("SqlRender interpolation is textual (documents why the old code broke)", {
+  skip_if_not_installed("SqlRender")
+  # This is not an assertion about Keeper's code — it documents the
+  # vulnerability in the original implementation: SqlRender's @-token
+  # substitution is textual and therefore unsafe for user-supplied values.
+  vulnerable <- SqlRender::render(
+    "SET phenotype = '@phenotype';",
+    phenotype = "Crohn's disease"
+  )
+  expect_equal(vulnerable, "SET phenotype = 'Crohn's disease';")
+})


### PR DESCRIPTION
## Summary

The three `UPDATE` statements in `inst/shiny/server.R` (decision, certainty, index_day) built SQL by SqlRender `@`-token substitution, wrapping values in single quotes. Textual substitution has two problems:

1. **Correctness**: a legitimate phenotype like `Crohn's disease` terminates the string literal early and produces malformed SQL — the reviewer's decision is silently lost.
2. **Security**: anyone who can influence `input$decision`, `input$certainty`, `delayedIndexDay()`, or write `phenotype`/`database_id` into the source keeper table can inject arbitrary SQL under the reviewer's DB role.

## Fix

- New internal helper `R/ShinyDbHelpers.R::updateAdjudication()` builds the statement with only the schema and column interpolated (both allowlist-validated) and passes every other value to `DBI::dbExecute` as a bound parameter.
- `inst/shiny/server.R` — the 3 handlers now call the helper.
- `DESCRIPTION` — `DBI` added to `Imports` (was transitive via `DatabaseConnector`).

## Test plan

- [x] New `tests/testthat/test-shiny-db-helpers.R` covers placeholder shape, column/schema allowlists, apostrophe-bearing phenotypes, injection payloads, and integer coercion.
- [x] `R-CMD-check` passes on windows/macOS/ubuntu (release) on the fork branch.
- [ ] Manual smoke test of the Shiny app against a DB-backed configuration with a phenotype containing an apostrophe (recommend reviewer verify before merge).