### PR TITLE
Use Hecate Phoebe bulk endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ Changes:
 
 7. Switched from `condition_era` to `condition_occurrence`.
 
+8. `generateKeeperConceptSets()` now uses the Hecate Phoebe bulk endpoint to reduce request volume when adding related concepts.
+
 
 Bug fixes:
 

--- a/R/GenerateConceptSets.R
+++ b/R/GenerateConceptSets.R
@@ -63,45 +63,72 @@ vectorSearch <- function(term, domains, conceptClasses, limit = 10, maxRetries =
   stop(sprintf("All %s attempts failed for term '%s'.", maxRetries, term))
 }
 
-phoebeSearch <- function(conceptId, maxRetries = 3, waitTime = 2) {
-  url <- sprintf("https://hecate.pantheon-hds.com/api/concepts/%d/phoebe", conceptId)
-
-  for (attempt in 1:maxRetries) {
-    response <- tryCatch(
-      {
-        httr::GET(url)
-      },
-      error = function(e) {
-        message(paste("Attempt", attempt, "failed with connection error for concept", conceptId))
-        return(NULL)
-      }
-    )
-
-    if (!is.null(response) && httr::status_code(response) == 200) {
-      contextText <- httr::content(response, "text", encoding = "UTF-8")
-
-      if (contextText == "[]") {
-        return(NULL)
-      }
-      data <- jsonlite::fromJSON(contextText)
-      data <- data |>
-        SqlRender::snakeCaseToCamelCaseNames()
-
-      return(data)
-    }
-    if (attempt < maxRetries) {
-      statusMsg <- if (is.null(response)) "Connection Error" else httr::status_code(response)
-      message(sprintf(
-        "Phoebe search failed (Status: %s). Retrying in %s seconds...",
-        statusMsg, waitTime
-      ))
-      Sys.sleep(waitTime)
-    }
+phoebeBulkSearch <- function(conceptIds, maxRetries = 3, waitTime = 2, chunkSize = 100) {
+  conceptIds <- unique(as.integer(conceptIds[!is.na(conceptIds)]))
+  if (length(conceptIds) == 0) {
+    return(tibble())
   }
-  stop(sprintf(
-    "Error in phoebe search for concept %s after %s attempts.",
-    conceptId, maxRetries
-  ))
+  url <- "https://hecate.pantheon-hds.com/api/concepts/phoebe/bulk"
+  chunks <- split(conceptIds, ceiling(seq_along(conceptIds) / chunkSize))
+  results <- list()
+
+  for (chunk in chunks) {
+    chunkResults <- NULL
+    for (attempt in 1:maxRetries) {
+      response <- tryCatch(
+        {
+          httr::POST(url, body = list(ids = chunk), encode = "json")
+        },
+        error = function(e) {
+          message(paste("Attempt", attempt, "failed with connection error for Phoebe bulk search"))
+          return(NULL)
+        }
+      )
+
+      if (!is.null(response) && httr::status_code(response) == 200) {
+        contextText <- httr::content(response, "text", encoding = "UTF-8")
+
+        if (contextText == "[]") {
+          chunkResults <- tibble()
+          break
+        }
+        # The bulk endpoint returns one element per requested id, each holding a
+        # `concept_id` and a `results` table of related concepts. Stack those
+        # tables together, tagging each row with the source concept it came from.
+        data <- jsonlite::fromJSON(contextText, simplifyDataFrame = TRUE)
+        chunkConcepts <- Map(
+          function(sourceConceptId, relatedConcepts) {
+            if (NROW(relatedConcepts) == 0) {
+              return(NULL)
+            }
+            relatedConcepts$source_concept_id <- sourceConceptId
+            relatedConcepts
+          },
+          data$concept_id,
+          data$results
+        )
+        chunkResults <- bind_rows(chunkConcepts) |>
+          SqlRender::snakeCaseToCamelCaseNames()
+        break
+      }
+      if (attempt < maxRetries) {
+        statusMsg <- if (is.null(response)) "Connection Error" else httr::status_code(response)
+        message(sprintf(
+          "Phoebe bulk search failed (Status: %s). Retrying in %s seconds...",
+          statusMsg, waitTime
+        ))
+        Sys.sleep(waitTime)
+      }
+    }
+    if (is.null(chunkResults)) {
+      stop(sprintf(
+        "Error in Phoebe bulk search after %s attempts.",
+        maxRetries
+      ))
+    }
+    results[[length(results) + 1]] <- chunkResults
+  }
+  return(bind_rows(results))
 }
 
 removeChildren <- function(concepts, connection, vocabDatabaseSchema) {
@@ -386,8 +413,7 @@ generateConceptSet <- function(phenotype,
 
   message("- Adding related concepts using Phoebe")
   if (nrow(concepts) != 0) {
-    newConcepts <- lapply(concepts$conceptId, phoebeSearch)
-    newConcepts <- bind_rows(newConcepts)
+    newConcepts <- phoebeBulkSearch(concepts$conceptId)
     if (nrow(newConcepts) > 0) {
       newConcepts <- newConcepts |>
         filter(!duplicated(.data$conceptId)) |>

--- a/tests/testthat/test-generate-concept-sets.R
+++ b/tests/testthat/test-generate-concept-sets.R
@@ -12,6 +12,80 @@ test_that("generateKeeperConceptSets validates inputs", {
   )
 })
 
+test_that("phoebeBulkSearch posts concept IDs in chunks and flattens results", {
+  calls <- list()
+  response <- structure(list(status_code = 200), class = "fake_response")
+
+  local_mocked_bindings(
+    POST = function(url, body, encode) {
+      calls[[length(calls) + 1]] <<- list(url = url, body = body, encode = encode)
+      response
+    },
+    status_code = function(response) response$status_code,
+    content = function(response, as, encoding) {
+      sourceConceptId <- calls[[length(calls)]]$body$ids[[1]]
+      jsonlite::toJSON(list(
+        list(
+          concept_id = sourceConceptId,
+          results = list(
+            list(
+              relationship_id = "Lexical via standard",
+              concept_id = sourceConceptId + 1000L,
+              concept_name = "Related concept",
+              vocabulary_id = "SNOMED",
+              record_count = 30000L
+            )
+          )
+        )
+      ), auto_unbox = TRUE)
+    },
+    .package = "httr"
+  )
+
+  result <- Keeper:::phoebeBulkSearch(1:101, chunkSize = 100)
+
+  expect_length(calls, 2)
+  expect_equal(calls[[1]]$url, "https://hecate.pantheon-hds.com/api/concepts/phoebe/bulk")
+  expect_equal(calls[[1]]$body$ids, 1:100)
+  expect_equal(calls[[2]]$body$ids, 101L)
+  expect_equal(calls[[1]]$encode, "json")
+  expect_equal(nrow(result), 2)
+  expect_named(
+    result,
+    c("relationshipId", "conceptId", "conceptName", "vocabularyId", "recordCount", "sourceConceptId")
+  )
+  expect_equal(result$conceptId, c(1001L, 1101L))
+  expect_equal(result$sourceConceptId, c(1L, 101L))
+})
+
+test_that("phoebeBulkSearch handles ids with no related concepts", {
+  # The bulk endpoint echoes back every requested id, returning an empty
+  # `results` array for ids that have no related concepts (and `[]` overall
+  # when nothing matches), so both must flatten to an empty result.
+  local_mocked_bindings(
+    POST = function(url, body, encode) {
+      structure(list(status_code = 200, ids = body$ids), class = "fake_response")
+    },
+    status_code = function(response) response$status_code,
+    content = function(response, as, encoding) {
+      if (identical(response$ids, 0L)) {
+        return("[]")
+      }
+      jsonlite::toJSON(
+        lapply(response$ids, function(id) list(concept_id = id, results = list())),
+        auto_unbox = TRUE
+      )
+    },
+    .package = "httr"
+  )
+
+  emptyResults <- Keeper:::phoebeBulkSearch(c(10L, 20L))
+  expect_equal(nrow(emptyResults), 0)
+
+  emptyResponse <- Keeper:::phoebeBulkSearch(0L)
+  expect_equal(nrow(emptyResponse), 0)
+})
+
 test_that("generateKeeperConceptSets orchestrates DOI and alternative diagnosis flows", {
   callLog <- list()
   fakePrompts <- list(


### PR DESCRIPTION
Hey @schuemie ,

The past month I've had over 245.000 calls come in at the /phoebe endpoint (from 40 users only...) and Joel reached out with the question if maybe he could get requests bulked for Phenelope, so I've added a bulk endpoint and thought I might as well get you guys in on it also (even though sorting out phoebe locally at scale makes more sense to me...)

Hope its of some use :-)

Rowan